### PR TITLE
Add the API server `serverencryptionProviderConfigFile`, and kubelet service files info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/codegangsta/negroni v1.0.0
+	github.com/coreos/go-systemd/v22 v22.4.0
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/weaveworks/procspy v0.0.0-20150706124340-cb970aa190c3
 	go.uber.org/zap v1.19.1
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,15 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/coreos/go-systemd/v22 v22.4.0 h1:y9YHcjnjynCd/DVbg5j9L/33jQM3MxJlbj/zWskzfGU=
+github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/sensor/controlplanesensor.go
+++ b/sensor/controlplanesensor.go
@@ -9,18 +9,18 @@ import (
 )
 
 const (
-	apiServerExe         = "/kube-apiserver"
-	controllerManagerExe = "/kube-controller-manager"
-	schedulerExe         = "/kube-scheduler"
-	etcdExe              = "/etcd"
-	etcdDataDirArg       = "--data-dir"
+	apiServerExe                   = "/kube-apiserver"
+	controllerManagerExe           = "/kube-controller-manager"
+	schedulerExe                   = "/kube-scheduler"
+	etcdExe                        = "/etcd"
+	etcdDataDirArg                 = "--data-dir"
+	apiEncryptionProviderConfigArg = "--encryption-provider-config"
 
 	// Default files paths according to https://workbench.cisecurity.org/benchmarks/8973/sections/1126652
 	apiServerSpecsPath          = "/etc/kubernetes/manifests/kube-apiserver.yaml"
 	controllerManagerSpecsPath  = "/etc/kubernetes/manifests/kube-controller-manager.yaml"
 	controllerManagerConfigPath = "/etc/kubernetes/controller-manager.conf"
 	schedulerSpecsPath          = "/etc/kubernetes/manifests/kube-scheduler.yaml"
-	schedulerKubeConfigPath     = "/etc/kubernetes/scheduler.conf"
 	schedulerConfigPath         = "/etc/kubernetes/scheduler.conf"
 	etcdConfigPath              = "/etc/kubernetes/manifests/etcd.yaml"
 	adminConfigPath             = "/etc/kubernetes/admin.conf"
@@ -35,7 +35,7 @@ var (
 
 // KubeProxyInfo holds information about kube-proxy process
 type ControlPlaneInfo struct {
-	APIServerInfo         *K8sProcessInfo `json:"APIServerInfo,omitempty"`
+	APIServerInfo         *ApiServerInfo  `json:"APIServerInfo,omitempty"`
 	ControllerManagerInfo *K8sProcessInfo `json:"controllerManagerInfo,omitempty"`
 	SchedulerInfo         *K8sProcessInfo `json:"schedulerInfo,omitempty"`
 	EtcdConfigFile        *FileInfo       `json:"etcdConfigFile,omitempty"`
@@ -61,6 +61,11 @@ type K8sProcessInfo struct {
 
 	// Raw cmd line of the process
 	CmdLine string `json:"cmdLine"`
+}
+
+type ApiServerInfo struct {
+	EncryptionProviderConfigFile *FileInfo `json:"encryptionProviderConfigFile,omitempty"`
+	*K8sProcessInfo              `json:",inline"`
 }
 
 // getEtcdDataDir find the `data-dir` path of etcd k8s component
@@ -119,6 +124,22 @@ func makeProcessInfoVerbose(p *ProcessDetails, specsPath, configPath, kubeConfig
 	return &ret
 }
 
+// makeAPIserverEncryptionProviderConfigFile returns a FileInfo object for the encryption provider config file of the API server. Required for https://workbench.cisecurity.org/sections/1126663/recommendations/1838675
+func makeAPIserverEncryptionProviderConfigFile(p *ProcessDetails) *FileInfo {
+	encryptionProviderConfigPath, ok := p.GetArg(apiEncryptionProviderConfigArg)
+	if !ok {
+		zap.L().Warn("failed to find encryption provider config path", zap.String("in", "makeAPIserverEncryptionProviderConfigFile"))
+		return nil
+	}
+
+	fi, err := makeContaineredFileInfo(encryptionProviderConfigPath, true, p)
+	if err != nil {
+		zap.L().Warn("failed to create encryption provider config file info", zap.Error(err))
+		return nil
+	}
+	return fi
+}
+
 // SenseControlPlaneInfo return `ControlPlaneInfo`
 func SenseControlPlaneInfo() (*ControlPlaneInfo, error) {
 	var err error
@@ -141,7 +162,9 @@ func SenseControlPlaneInfo() (*ControlPlaneInfo, error) {
 		zap.L().Error("SenseControlPlaneInfo", zap.Error(err))
 	}
 
-	ret.APIServerInfo = makeProcessInfoVerbose(apiProc, apiServerSpecsPath, "", "", "")
+	ret.APIServerInfo = &ApiServerInfo{}
+	ret.APIServerInfo.K8sProcessInfo = makeProcessInfoVerbose(apiProc, apiServerSpecsPath, "", "", "")
+	ret.APIServerInfo.EncryptionProviderConfigFile = makeAPIserverEncryptionProviderConfigFile(apiProc)
 	ret.ControllerManagerInfo = makeProcessInfoVerbose(controllerMangerProc, controllerManagerSpecsPath, controllerManagerConfigPath, "", "")
 	ret.SchedulerInfo = makeProcessInfoVerbose(SchedulerProc, schedulerSpecsPath, schedulerConfigPath, "", "")
 
@@ -185,7 +208,7 @@ func SenseControlPlaneInfo() (*ControlPlaneInfo, error) {
 	}
 
 	// If wasn't able to find any data - this is not a control plane
-	if ret.APIServerInfo == nil &&
+	if ret.APIServerInfo.K8sProcessInfo == nil &&
 		ret.ControllerManagerInfo == nil &&
 		ret.SchedulerInfo == nil &&
 		ret.EtcdConfigFile == nil &&

--- a/sensor/kubeletsensor.go
+++ b/sensor/kubeletsensor.go
@@ -20,6 +20,10 @@ const (
 
 // KubeletInfo holds information about kubelet
 type KubeletInfo struct {
+	// ServiceFile is a list of files used to configure the kubelet service.
+	// Most of the times it will be a single file, under /etc/systemd/system/kubelet.service.d.
+	ServiceFiles []FileInfo `json:"serviceFiles,omitempty"`
+
 	// Information about kubelete config file
 	ConfigFile *FileInfo `json:"configFile,omitempty"`
 
@@ -43,6 +47,28 @@ func ReadKubeletConfig(kubeletConfArgs string) ([]byte, error) {
 	return conte, err
 }
 
+func makeKubeletServiceFilesInfo(pid int) []FileInfo {
+	files, err := getKubeletServiceFiles(pid)
+	if err != nil {
+		zap.L().Warn("failed to getKubeletServiceFiles", zap.Error(err))
+		return nil
+	}
+
+	serviceFiles := []FileInfo{}
+	for _, file := range files {
+		info := makeHostFileInfoVerbose(file, false, zap.String("in", "makeProcessInfoVerbose"))
+		if info != nil {
+			serviceFiles = append(serviceFiles, *info)
+		}
+	}
+
+	if len(serviceFiles) == 0 {
+		return nil
+	}
+
+	return serviceFiles
+}
+
 // SenseKubeletInfo return varius information about the kubelet service
 func SenseKubeletInfo() (*KubeletInfo, error) {
 	ret := KubeletInfo{}
@@ -51,6 +77,9 @@ func SenseKubeletInfo() (*KubeletInfo, error) {
 	if err != nil {
 		return &ret, fmt.Errorf("failed to LocateKubeletProcess: %w", err)
 	}
+
+	// Serivce files
+	ret.ServiceFiles = makeKubeletServiceFilesInfo(int(kubeletProcess.PID))
 
 	// Kubelet config
 	configPath := kubeletConfigDefaultPath

--- a/sensor/osuserswrapper_test.go
+++ b/sensor/osuserswrapper_test.go
@@ -7,6 +7,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetUserName(t *testing.T) {
+	userGroupCache = map[string]userGroupCacheItem{}
+	// regular
+	t.Run("regular", func(t *testing.T) {
+		name, _ := getUserName(0, "testdata")
+		assert.Equal(t, "root", name)
+		assert.Contains(t, userGroupCache, "testdata")
+		assert.Contains(t, userGroupCache["testdata"].users, "0")
+		assert.Equal(t, "root", userGroupCache["testdata"].users["0"])
+	})
+
+	// cached
+	t.Run("cached", func(t *testing.T) {
+		userGroupCache["foo"] = userGroupCacheItem{
+			users:  map[string]string{"0": "bar"},
+			groups: map[string]string{},
+		}
+		name, _ := getUserName(0, "foo")
+		assert.Equal(t, "bar", name)
+	})
+}
+
+func TestGetGroupName(t *testing.T) {
+	userGroupCache = map[string]userGroupCacheItem{}
+
+	// regular
+	t.Run("regular", func(t *testing.T) {
+		name, _ := getGroupName(0, "testdata")
+		assert.Equal(t, "root", name)
+		assert.Contains(t, userGroupCache, "testdata")
+		assert.Contains(t, userGroupCache["testdata"].groups, "0")
+		assert.Equal(t, "root", userGroupCache["testdata"].groups["0"])
+	})
+
+	// cached
+	t.Run("cached", func(t *testing.T) {
+		userGroupCache["foo"] = userGroupCacheItem{
+			users:  map[string]string{},
+			groups: map[string]string{"0": "bar"},
+		}
+		name, _ := getGroupName(0, "foo")
+		assert.Equal(t, "bar", name)
+	})
+}
+
 func Test_LookupUsernameByUID(t *testing.T) {
 	uid_tests := []struct {
 		name        string

--- a/sensor/service.go
+++ b/sensor/service.go
@@ -1,0 +1,110 @@
+package sensor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+
+	systemd_debus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+	"go.uber.org/zap"
+)
+
+// This file contains utilities for the getting information about services
+
+const (
+	// https://wiki.archlinux.org/title/Systemd
+	systemdPkgDir   = "/usr/lib/systemd/system/" // units provided by installed packages
+	systemdAdminDir = "/etc/systemd/system/"     // units installed by the system administrator
+
+	// default service paths
+	kubeletSystemdServiceConfigDir = systemdAdminDir + "kubelet.service.d"
+)
+
+var (
+	ErrServicePathNotFound = errors.New("cannot locate service file path")
+)
+
+func newSystemDbusConnection() (*dbus.Conn, error) {
+	systemBusPath := "unix:path=" + hostPath("/run/dbus/system_bus_socket")
+	d, err := dbus.Dial(systemBusPath)
+	if err != nil {
+		return d, err
+	}
+	err = d.Auth(nil)
+	if err != nil {
+		return d, err
+	}
+	err = d.Hello()
+	return d, err
+}
+
+// getKubeletServiceFiles all the service files associated with the kubelet service.
+func getKubeletServiceFiles(kubeletPid int) ([]string, error) {
+
+	// First try to get the service files from systemd daemon
+	configDir, err := getServiceFilesByPIDSystemd(kubeletPid)
+	if err != nil {
+		zap.L().Debug("failed to get service files by PID from systemd", zap.Error(err))
+	}
+
+	// Fallback to the default location
+	// if can't find the service files path dynamically
+	if configDir == "" {
+		configDir = kubeletSystemdServiceConfigDir
+	}
+
+	files, err := os.ReadDir(hostPath(configDir))
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{}
+	for _, f := range files {
+		ret = append(ret, path.Join(configDir, f.Name()))
+	}
+
+	return ret, nil
+}
+
+// getServiceFilesByPIDSystemd returns the serivce config directory for a given process id.
+func getServiceFilesByPIDSystemd(pid int) (string, error) {
+	conn, err := systemd_debus.NewConnection(newSystemDbusConnection)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	unitName, err := conn.GetUnitNameByPID(context.Background(), uint32(pid))
+	if err != nil {
+		return "", err
+	}
+
+	// Get the service file path
+	// p, err := conn.GetUnitPropertyContext(context.Background(), unitName, "FragmentPath")
+	// if err != nil {
+	// 	return "", nil, err
+	// }
+	// servicePath := p.Value.String()
+	// servicePath = servicePath[1 : len(servicePath)-1] // remove quotes
+
+	// Find the service override files path (if any)
+	unitDirName := unitName + ".d"
+	configDir := getExistsPath(hostFileSystemDefaultLocation,
+		path.Join(systemdPkgDir, unitDirName),
+		path.Join(systemdAdminDir, unitDirName),
+	)
+
+	return configDir, nil
+}
+
+// getExistsPath return the first exists path from a list of `paths`, prefixing it with `rootDir`.
+func getExistsPath(rootDir string, paths ...string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(path.Join(rootDir, p)); err == nil {
+			return p
+		}
+	}
+	return ""
+}

--- a/sensor/utils.go
+++ b/sensor/utils.go
@@ -122,10 +122,10 @@ func makeChangedRootFileInfo(filePath string, readContent bool, rootDir string) 
 		return obj, err
 	}
 
-	obj.Path = fullPath
+	obj.Path = filePath
 
 	// Username
-	username, err := lookupUsernameByUID(obj.Ownership.UID, rootDir)
+	username, err := getUserName(obj.Ownership.UID, rootDir)
 	obj.Ownership.Username = username
 
 	if err != nil {
@@ -133,7 +133,7 @@ func makeChangedRootFileInfo(filePath string, readContent bool, rootDir string) 
 	}
 
 	// Groupname
-	groupname, err := LookupGroupnameByGID(obj.Ownership.GID, rootDir)
+	groupname, err := getGroupName(obj.Ownership.GID, rootDir)
 	obj.Ownership.Groupname = groupname
 
 	if err != nil {


### PR DESCRIPTION
## Describe your changes
- Add group and user name cache, in order not to parse the `/etc/passwd` every time
- Fix a bug related to the file path
- Add the API server `serverencryptionProviderConfigFile` info to the API server info
- Locate the kubelet service files (via communication with the systemd daemon) and add their info to the `kubeletInfo` endpoint response.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
