### PR TITLE
C-0052 - check access to cloud provider meta data API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jarcoal/httpmock v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/armosec/utils-go v0.0.12
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
+github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
+github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/httphandlers.go
+++ b/httphandlers.go
@@ -47,6 +47,12 @@ func initHTTPHandlers() {
 	http.HandleFunc("/kubeletInfo", kubeletInfoHandler)
 	http.HandleFunc("/kubeProxyInfo", kubeProxyHandler)
 	http.HandleFunc("/controlPlaneInfo", controlPlaneHandler)
+	http.HandleFunc("/cloudProviderInfo", cloudProviderHandler)
+}
+
+func cloudProviderHandler(rw http.ResponseWriter, r *http.Request) {
+	resp, err := sensor.SenseCloudProviderInfo()
+	GenericSensorHandler(rw, r, resp, err, "SenseCloudProviderInfo")
 }
 
 func controlPlaneHandler(rw http.ResponseWriter, r *http.Request) {

--- a/sensor/cloudProvider.go
+++ b/sensor/cloudProvider.go
@@ -12,21 +12,11 @@ type CloudProviderInfo struct {
 	ProviderMetaDataAPIAccess bool `json:"providerMetaDataAPIAccess,omitempty"`
 }
 
-// SenseCloudProviderInfo returns `CloudProviderInfo`
-func SenseCloudProviderInfo() (*CloudProviderInfo, error) {
-
-	ret := CloudProviderInfo{}
-
-	ret.ProviderMetaDataAPIAccess = hasMetaDataAPIAccess()
-
-	return &ret, nil
-}
-
-// hasMetaDataAPIAccess - checks if there is an access to cloud provider meta data
+// MetaDataAPIRequests - hold information on major cloud providers meta data access urls.
 var MetaDataAPIRequests = []struct {
 	url     string
 	headers map[string]string
-} 	{
+}{
 	{
 		"http://169.254.169.254/computeMetadata/v1/?alt=json&recursive=true",
 		map[string]string{"Metadata-Flavor": "Google"},
@@ -41,15 +31,26 @@ var MetaDataAPIRequests = []struct {
 	},
 }
 
+// SenseCloudProviderInfo returns `CloudProviderInfo`
+func SenseCloudProviderInfo() (*CloudProviderInfo, error) {
+
+	ret := CloudProviderInfo{}
+
+	ret.ProviderMetaDataAPIAccess = hasMetaDataAPIAccess()
+
+	return &ret, nil
+}
+
+// hasMetaDataAPIAccess - checks if there is an access to cloud provider meta data
 func hasMetaDataAPIAccess() bool {
 	client := &http.Client{}
 
-	for _,req := range MetaDataAPIRequests {
+	for _, req := range MetaDataAPIRequests {
 		res, err := httputils.HttpGet(client, req.url, req.headers)
 
 		if err == nil && res.StatusCode == 200 {
 			return true
-		}	
+		}
 	}
 
 	return false

--- a/sensor/cloudProvider.go
+++ b/sensor/cloudProvider.go
@@ -1,9 +1,8 @@
 package sensor
 
 import (
-	"net/http"
-
 	"github.com/armosec/utils-go/httputils"
+	"github.com/kubescape/host-scanner/sensor/internal/utils"
 )
 
 // CloudProviderInfo holds information about the Cloud Provider
@@ -43,7 +42,8 @@ func SenseCloudProviderInfo() (*CloudProviderInfo, error) {
 
 // hasMetaDataAPIAccess - checks if there is an access to cloud provider meta data
 func hasMetaDataAPIAccess() bool {
-	client := &http.Client{}
+	client := utils.GetHttpClient()
+	client.Timeout = 1000000000
 
 	for _, req := range MetaDataAPIRequests {
 		res, err := httputils.HttpGet(client, req.url, req.headers)

--- a/sensor/cloudProvider.go
+++ b/sensor/cloudProvider.go
@@ -11,11 +11,14 @@ type CloudProviderInfo struct {
 	ProviderMetaDataAPIAccess bool `json:"providerMetaDataAPIAccess,omitempty"`
 }
 
-// MetaDataAPIRequests - hold information on major cloud providers meta data access urls.
-var MetaDataAPIRequests = []struct {
+// APIsURLs - hold urls along with their headers.
+type APIsURLs struct {
 	url     string
 	headers map[string]string
-}{
+}
+
+// CloudProviderMetaDataAPIs - hold information on major cloud providers meta data access urls.
+var CloudProviderMetaDataAPIs = []APIsURLs{
 	{
 		"http://169.254.169.254/computeMetadata/v1/?alt=json&recursive=true",
 		map[string]string{"Metadata-Flavor": "Google"},
@@ -45,7 +48,7 @@ func hasMetaDataAPIAccess() bool {
 	client := utils.GetHttpClient()
 	client.Timeout = 1000000000
 
-	for _, req := range MetaDataAPIRequests {
+	for _, req := range CloudProviderMetaDataAPIs {
 		res, err := httputils.HttpGet(client, req.url, req.headers)
 
 		if err == nil && res.StatusCode == 200 {

--- a/sensor/cloudProvider.go
+++ b/sensor/cloudProvider.go
@@ -1,0 +1,49 @@
+package sensor
+
+import (
+	"net/http"
+
+	"github.com/armosec/utils-go/httputils"
+)
+
+// CloudProviderInfo holds information about the Cloud Provider
+type CloudProviderInfo struct {
+	// Has access to cloud provider meta data API
+	ProviderMetaDataAPIAccess bool `json:"hasMetaDataAPIAccess,omitempty"`
+}
+
+// SenseCloudProviderInfo returns `CloudProviderInfo`
+func SenseCloudProviderInfo() (*CloudProviderInfo, error) {
+
+	ret := CloudProviderInfo{}
+
+	ret.ProviderMetaDataAPIAccess = hasMetaDataAPIAccess()
+
+	return &ret, nil
+}
+
+// hasMetaDataAPIAccess - checks if there is an access to cloud provider meta data
+func hasMetaDataAPIAccess() bool {
+	client := &http.Client{}
+
+	res, err := httputils.HttpGet(client, "http://169.254.169.254/computeMetadata/v1/?alt=json&recursive=true", map[string]string{"Metadata-Flavor": "Google"})
+
+	if err == nil && res.StatusCode == 200 {
+		return true
+	}
+
+	res, err = httputils.HttpGet(client, "http://169.254.169.254/metadata/instance?api-version=2021-02-01", map[string]string{"Metadata": "true"})
+
+	if err == nil && res.StatusCode == 200 {
+		return true
+	}
+
+	res, err = httputils.HttpGet(client, "http://169.254.169.254/latest/meta-data/local-hostname", nil)
+
+	if err == nil && res.StatusCode == 200 {
+		return true
+	}
+
+	return false
+
+}

--- a/sensor/cloudProvider.go
+++ b/sensor/cloudProvider.go
@@ -9,7 +9,7 @@ import (
 // CloudProviderInfo holds information about the Cloud Provider
 type CloudProviderInfo struct {
 	// Has access to cloud provider meta data API
-	ProviderMetaDataAPIAccess bool `json:"hasMetaDataAPIAccess,omitempty"`
+	ProviderMetaDataAPIAccess bool `json:"providerMetaDataAPIAccess,omitempty"`
 }
 
 // SenseCloudProviderInfo returns `CloudProviderInfo`

--- a/sensor/cloudProvider_test.go
+++ b/sensor/cloudProvider_test.go
@@ -15,10 +15,7 @@ func Test_hasMetaDataAPIAccess(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://www.mygoodurl.com",
 		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Good URL"}]`))
 
-	MetaDataAPIRequests = []struct {
-		url     string
-		headers map[string]string
-	}{
+	CloudProviderMetaDataAPIs = []APIsURLs{
 		{
 			"http://www.mygoodurl.com",
 			map[string]string{},
@@ -34,10 +31,7 @@ func Test_hasMetaDataAPIAccess(t *testing.T) {
 		assert.Equal(t, true, res)
 	})
 
-	MetaDataAPIRequests = []struct {
-		url     string
-		headers map[string]string
-	}{
+	CloudProviderMetaDataAPIs = []APIsURLs{
 		{
 			"http://10.20.30.100",
 			map[string]string{},

--- a/sensor/cloudProvider_test.go
+++ b/sensor/cloudProvider_test.go
@@ -1,0 +1,51 @@
+package sensor
+
+import (
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_hasMetaDataAPIAccess(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Exact URL match
+	httpmock.RegisterResponder("GET", "http://www.mygoodurl.com",
+		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Good URL"}]`))
+
+	MetaDataAPIRequests = []struct {
+		url     string
+		headers map[string]string
+	}{
+		{
+			"http://www.mygoodurl.com",
+			map[string]string{},
+		},
+		{
+			"http://10.20.30.100",
+			map[string]string{},
+		},
+	}
+
+	t.Run("Has Access", func(t *testing.T) {
+		res := hasMetaDataAPIAccess()
+		assert.Equal(t, true, res)
+	})
+
+	MetaDataAPIRequests = []struct {
+		url     string
+		headers map[string]string
+	}{
+		{
+			"http://10.20.30.100",
+			map[string]string{},
+		},
+	}
+
+	t.Run("No Access", func(t *testing.T) {
+		res := hasMetaDataAPIAccess()
+		assert.Equal(t, false, res)
+	})
+}

--- a/sensor/controlplane.go
+++ b/sensor/controlplane.go
@@ -53,9 +53,6 @@ type ControlPlaneInfo struct {
 
 	// The name of the running CNI
 	CNIName string `json:"CNIName,omitempty"`
-
-	// Has access to cloud provider meta data API
-	ProviderMetaDataAPIAccess bool `json:"hasMetaDataAPIAccess,omitempty"`
 }
 
 // K8sProcessInfo holds information about a k8s process
@@ -321,8 +318,6 @@ func SenseControlPlaneInfo() (*ControlPlaneInfo, error) {
 	// get CNI name
 	ret.CNIName = getCNIName()
 
-	ret.ProviderMetaDataAPIAccess = hasMetaDataAPIAccess()
-
 	// If wasn't able to find any data - this is not a control plane
 	if ret.APIServerInfo == nil &&
 		ret.ControllerManagerInfo == nil &&
@@ -402,55 +397,4 @@ func getCNIName() string {
 	zap.L().Debug("No supported CNI process was found")
 
 	return ""
-}
-
-// hasMetaDataAPIAccess - checks if there is an access to cloud provider meta data
-func hasMetaDataAPIAccess() bool {
-	client := &http.Client{}
-
-	// check if a url has access from node.
-	hasAccess := func(url string, header_name string, header_value string) bool {
-		resp, err := client.Get(url)
-		if err != nil {
-			return false
-		}
-
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			return false
-		}
-
-		if header_name != "" && header_value != "" {
-			req.Header.Add(header_name, header_value)
-		}
-
-		resp, err = client.Do(req)
-		if err == nil {
-			if resp.StatusCode == 200 {
-				return true
-			}
-		}
-		return false
-	}
-
-	res := hasAccess("http://169.254.169.254/computeMetadata/v1/?alt=json&recursive=true", "Metadata-Flavor", "Google")
-
-	if res {
-		return true
-	}
-
-	res = hasAccess("http://169.254.169.254/metadata/instance?api-version=2021-02-01", "Metadata", "true")
-
-	if res {
-		return true
-	}
-
-	res = hasAccess("http://169.254.169.254/latest/meta-data/local-hostname", "", "")
-
-	if res {
-		return true
-	}
-
-	return false
-
 }

--- a/sensor/internal/utils/globals.go
+++ b/sensor/internal/utils/globals.go
@@ -1,7 +1,29 @@
 package utils
 
+import (
+	"net/http"
+	"sync"
+)
+
 var (
 	// Where the host sensor is expecting host fs to be mounted.
 	// Defined as var for testing purposes only
 	HostFileSystemDefaultLocation = "/host_fs"
+
+	// global http.client instance to reduce object resource overuse.
+	httpClient *http.Client
+
+	lock = &sync.Mutex{}
 )
+
+// GetHttpClient - instantiate http.client object
+func GetHttpClient() *http.Client {
+	if httpClient == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		if httpClient == nil {
+			httpClient = &http.Client{}
+		}
+	}
+	return httpClient
+}

--- a/sensor/internal/utils/globals.go
+++ b/sensor/internal/utils/globals.go
@@ -13,14 +13,14 @@ var (
 	// global http.client instance to reduce object resource overuse.
 	httpClient *http.Client
 
-	lock = &sync.Mutex{}
+	httpClientCreationlock = &sync.Mutex{}
 )
 
 // GetHttpClient - instantiate http.client object
 func GetHttpClient() *http.Client {
 	if httpClient == nil {
-		lock.Lock()
-		defer lock.Unlock()
+		httpClientCreationlock.Lock()
+		defer httpClientCreationlock.Unlock()
 		if httpClient == nil {
 			httpClient = &http.Client{}
 		}


### PR DESCRIPTION
## Describe your changes
Added "ProviderMetaDataAPIAccess" entry - if true, cloud provider meta data API has access from Node.

References:

**aws API metadata:**
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
url to check :169.254.169.254/latest/meta-data/local-hostname

**Azure:**
https://learn.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows
url to check: http://169.254.169.254/metadata/instance?api-version=2021-02-01
"headers": {"Metadata": "true"}

**Google:**
https://cloud.google.com/compute/docs/metadata/querying-metadata
url to check: http://169.254.169.254/computeMetadata/v1/?alt=json&recursive=true
"headers": {"Metadata-Flavor": "Google"}


## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
