### PR TITLE
fix default kubelet kubeconfig and config paths, added support in EKS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,57 @@ Host-scanner is deployed as a privileged Kubernetes DaemonSet in the cluster. It
 ## Supported APIs
 
 **ControlPlaneInfo** - returns ControlPlane related information. Returns 404 if no information exist (=the node is not a control plane). [example](README.md#controlplaneinfo)
+```
+kubectl curl "http://<PODNAME>:7888/ControlPlaneInfo" -n <NAMESPACE>
 
+```
 **CNIInfo** - returns container network interface information. [example](README.md#cniinfo)
+```
+kubectl curl "http://<PODNAME>:7888/CNIInfo" -n <NAMESPACE>
+
+```
 
 **kernelVersion** - returns the kernel version. [example](README.md#kernelversion)
+```
+kubectl curl "http://<PODNAME>:7888/kernelVersion" -n <NAMESPACE>
+
+```
 
 **KubeletInfo** - returns kubelet information. [example](README.md#kubeletinfo)
+```
+kubectl curl "http://<PODNAME>:7888/KubeletInfo" -n <NAMESPACE>
+
+```
 
 **kubeProxyInfo** - returns kube-proxy command line info. [example](README.md#kubeproxyinfo)
+```
+kubectl curl "http://<PODNAME>:7888/kubeProxyInfo" -n <NAMESPACE>
+
+```
 
 **cloudProviderInfo** - returns information on cloud provider. [example](README.md#cloudproviderinfo)
+```
+kubectl curl "http://<PODNAME>:7888/cloudProviderInfo" -n <NAMESPACE>
+
+```
 
 **osRelease** - returns information on the node's operating system. [example](README.md#osrelease)
+```
+kubectl curl "http://<PODNAME>:7888/osRelease" -n <NAMESPACE>
+
+```
 
 **openedPorts** - returns information on open ports. [example](README.md#openedports)
+```
+kubectl curl "http://<PODNAME>:7888/openedPorts" -n <NAMESPACE>
+
+```
 
 **version** - returns the build version of the host-scanner.
+```
+kubectl curl "http://<PODNAME>:7888/version" -n <NAMESPACE>
+
+```
 
 
 

--- a/sensor/verboseutils.go
+++ b/sensor/verboseutils.go
@@ -24,6 +24,21 @@ func makeHostFileInfoVerbose(path string, readContent bool, failMsgs ...zap.Fiel
 	return makeChangedRootFileInfoVerbose(utils.HostFileSystemDefaultLocation, path, readContent, failMsgs...)
 }
 
+// makeContaineredFileInfoFromListVerbose makes a file info object
+// for a given process file system view, and with error logging.
+// It tries to find the file in the given list of paths, by the order of the list.
+// It returns nil on error.
+func makeContaineredFileInfoFromListVerbose(p *utils.ProcessDetails, filePathList []string, readContent bool, failMsgs ...zap.Field) *ds.FileInfo {
+
+	for _, filePath := range filePathList {
+		fileInfo := makeChangedRootFileInfoVerbose(p.RootDir(), filePath, readContent, failMsgs...)
+		if fileInfo != nil {
+			return fileInfo
+		}
+	}
+	return nil
+}
+
 // makeContaineredFileInfoVerbose makes a file info object
 // for a given process file system view, and with error logging.
 // It returns nil on error.


### PR DESCRIPTION
… default path

## Describe your changes
- Fixed bug - corrected usage of kubelet kubeConfig and config.
- Support in EKS kubelet kubeConfig and config - created a list of each config paths to be searched by order.

## Checklist before requesting a review
- [v] My code follows the style guidelines of this project
- [v] I have commented my code, particularly in hard-to-understand areas
- [v] I have performed a self-review of my code
- [v] If it is a core feature, I have added thorough tests.
- [v] New and existing unit tests pass locally with my changes
