### PR TITLE
fix(sensor): change proces name in error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,3 +583,11 @@ UBUNTU_CODENAME=focal
 	"icmpPorts": []
 }
 ```
+
+## Contributions
+
+Thanks to all our contributors! Check out our [CONTRIBUTING](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md) file to learn how to join them.
+
+* Feel free to pick a task from the [issues](https://github.com/kubescape/host-scanner/issues?q=is%3Aissue+is%3Aopen+label%3A%22open+for+contribution%22), roadmap or suggest a feature of your own.
+* [Open an issue](https://github.com/kubescape/host-scanner/issues/new/choose): we aim to respond to all issues within 48 hours.
+* [Join the CNCF Slack](https://slack.cncf.io/) and then our [users](https://cloud-native.slack.com/archives/C04EY3ZF9GE) or [developers](https://cloud-native.slack.com/archives/C04GY6H082K) channel.

--- a/sensor/controlplane.go
+++ b/sensor/controlplane.go
@@ -82,7 +82,7 @@ func getEtcdDataDir() (string, error) {
 
 	proc, err := utils.LocateProcessByExecSuffix(etcdExe)
 	if err != nil {
-		return "", fmt.Errorf("failed to locate kube-proxy process: %w", err)
+		return "", fmt.Errorf("failed to locate etcd process: %w", err)
 	}
 
 	dataDir, ok := proc.GetArg(etcdDataDirArg)


### PR DESCRIPTION
## Describe your changes

Fixed process name in the error message when searching for `etcd` process.
The error message was related to `kube-proxy` instead.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable in this fix)
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes