### PR TITLE
fix: controlplaneinfo returns 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Host-scanner is deployed as a privileged Kubernetes DaemonSet in the cluster. It
 
 Create host-scanner pod
 ```
-kubectl apply -f deployment/k8s-deployment.yaml 
+kubectl apply -f https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/hostsensorutils/hostsensor.yaml
+
+If command failed, use the below instead:
 ```
 
 Verify pod is launched successfully

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Host-scanner is deployed as a privileged Kubernetes DaemonSet in the cluster. It
 
 |  endpoint  |  test-command |  description  | example |
 |---|---|---|---|
-| `/controlplaneinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/controlplaneinfo" -n <NAMESPACE>` | Returns ControlPlane related information Returns `404` if case the node is not a control plane. | [example](docs/controlplaneinfo.json) |
+| `/controlplaneinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/controlplaneinfo" -n <NAMESPACE>` | Returns ControlPlane related information. | [example](docs/controlplaneinfo.json) |
 | `/cniinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/cniinfo" -n <NAMESPACE>` | Returns container network interface information. | [example](docs/cniinfo.json) |
 | `/kernelversion` | `kubectl curl "http://<host-scanner-pod-name>:7888/kernelversion" -n <NAMESPACE>` | Returns the kernel version. | [example](docs/kernelversion) |
 | `/kubeletinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/kubeletinfo" -n <NAMESPACE>` | Returns **kubelet** information. | [example](docs/kubeletinfo.json) |
@@ -173,8 +173,11 @@ Host-scanner is deployed as a privileged Kubernetes DaemonSet in the cluster. It
 Create host-scanner pod
 ```
 kubectl apply -f https://raw.githubusercontent.com/kubescape/kubescape/master/core/pkg/hostsensorutils/hostsensor.yaml
+```
 
 If command failed, use the below instead:
+```
+kubectl apply -f deployment/k8s-deployment.yaml
 ```
 
 Verify pod is launched successfully

--- a/sensor/controlplane.go
+++ b/sensor/controlplane.go
@@ -313,7 +313,7 @@ func SenseControlPlaneInfo(ctx context.Context) (*ControlPlaneInfo, error) {
 		return nil, &SenseError{
 			Massage:  "not a control plane node",
 			Function: "SenseControlPlaneInfo",
-			Code:     http.StatusNotFound,
+			Code:     http.StatusOK,
 		}
 	}
 


### PR DESCRIPTION
## Overview
This PR fix the status code provided by `/controlplaneinfo` endpoint when no control plane nodes occurred.
Since it is not a real error, we should consider this as an HTTP 200 OK status code.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

## How to Test
I tested it in this way:
1)  setup a cluster with **kind** using the following config file:
```
cat > kind-config.yaml <<EOF
# three node (two workers) cluster config
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: worker
- role: worker
EOF
```
and running this command:
```
kind create cluster --name host-scanner-test --config kind-config.yaml
```
2) Build the docke image of `host-scanner` locally:
```
docker build -f build/Dockerfile . -t kubescape/host-scanner:test 
```
3) Load the image on the cluster nodes:
```
kind load docker-image kubescape/host-scanner:test --nodes host-scanner-test-control-plane,host-scanner-test-worker,host-scanner-test-worker2 --name host-scanner-test
```
4) Apply the following manifest to the cluster:
```
cat > hostsensor.yaml <<EOF
apiVersion: v1
kind: Namespace
metadata:
  labels:
    app: kubescape-host-scanner
    k8s-app: kubescape-host-scanner
    kubernetes.io/metadata.name: kubescape-host-scanner
    tier: kubescape-host-scanner-control-plane
  name: kubescape-host-scanner
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: host-scanner
  namespace: kubescape-host-scanner
  labels:
    app: host-scanner
    k8s-app: kubescape-host-scanner
    otel: enabled
spec:
  selector:
    matchLabels:
      name: host-scanner
  template:
    metadata:
      labels:
        name: host-scanner
    spec:
      tolerations:
      # this toleration is to have the DaemonDet runnable on all nodes (including masters)
      # remove it if your masters can't run pods
      - operator: Exists
      containers:
      - name: host-sensor
        image: kubescape/host-scanner:test #quay.io/kubescape/host-scanner:v1.0.57
        imagePullPolicy: Never
        securityContext:
          allowPrivilegeEscalation: true
          privileged: true
          readOnlyRootFilesystem: true
          procMount: Unmasked
        ports:
          - name: scanner # Do not change port name
            containerPort: 7888
            protocol: TCP
        resources:
          limits:
            cpu: 0.1m
            memory: 200Mi
          requests:
            cpu: 1m
            memory: 200Mi
        volumeMounts:
        - mountPath: /host_fs
          name: host-filesystem
        readinessProbe:
          httpGet:
            path: /kernelVersion
            port: 7888
          initialDelaySeconds: 1
          periodSeconds: 1
      terminationGracePeriodSeconds: 120
      dnsPolicy: ClusterFirstWithHostNet
      automountServiceAccountToken: false
      volumes:
      - hostPath:
          path: /
          type: Directory
        name: host-filesystem
      hostPID: true
      hostIPC: true
EOF
```
5) Run a `curl` container to check the return status is fine:
```
kubectl run curl --image curlimages/curl -- sleep 3600
```
6) Retrieve `host-scanner` pods IPs:
```
kubectl -n kubescape-host-scanner get pod host-scanner-xxxx --template '{{.status.podIP}}'
```
and check it with curl:
```
kubectl exec -it curl -- curl http://<ip_of_host_scanner_pods>:7888/cloudproviderinfo -I
```
<!--
## Examples/Screenshots

> Here you add related screenshots 
-->
 
## Related issues/PRs:

Related to this: [SUB-1287](https://cyberarmor-io.atlassian.net/browse/SUB-1287)

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

