### PR TITLE
feat: add `/healthz` and `/readyz` endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Host-scanner is deployed as a privileged Kubernetes DaemonSet in the cluster. It
 
 |  endpoint  |  test-command |  description  | example |
 |---|---|---|---|
+| `/healthz` | `kubectl curl "http://<host-scanner-pod-name>:7888/healthz" -n <NAMESPACE>` | Returns liveness status of `host-scanner`. | [example] `{"alive": true}` |
+| `/readyz` | `kubectl curl "http://<host-scanner-pod-name>:7888/readyz" -n <NAMESPACE>` | Returns readiness status of `host-scanner`. Return `503` in case `host-scanner` is not ready yet. | [example] `{"ready": true}` |
 | `/controlplaneinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/controlplaneinfo" -n <NAMESPACE>` | Returns ControlPlane related information. | [example](docs/controlplaneinfo.json) |
 | `/cniinfo` | `kubectl curl "http://<host-scanner-pod-name>:7888/cniinfo" -n <NAMESPACE>` | Returns container network interface information. | [example](docs/cniinfo.json) |
 | `/kernelversion` | `kubectl curl "http://<host-scanner-pod-name>:7888/kernelversion" -n <NAMESPACE>` | Returns the kernel version. | [example](docs/kernelversion) |

--- a/httphandlers.go
+++ b/httphandlers.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -59,16 +57,25 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 <<<<<<< HEAD
+<<<<<<< HEAD
 	io.WriteString(w, `{"alive": true}`)
 =======
+=======
+>>>>>>> e44e154 (docs: update endpoint list with /healthz and /readyz)
 	_, err := w.Write([]byte(`{"alive": true}`))
 	if err != nil {
 		logger.
 			L().
+<<<<<<< HEAD
 			Ctx(r.Context()).
 			Error("failed to write response")
 	}
 >>>>>>> a4cf2e0 (a)
+=======
+			Ctx(context.TODO()).
+			Error("failed to write response")
+	}
+>>>>>>> e44e154 (docs: update endpoint list with /healthz and /readyz)
 }
 
 // setupReadyz set the atomic value to start checking the probe.
@@ -79,7 +86,6 @@ func setupReadyz(isReady *atomic.Value) {
 			L().
 			Ctx(context.Background()).
 			Info("Setting up readyz probe")
-		time.Sleep(10 * time.Second)
 		isReady.Store(true)
 		logger.
 			L().

--- a/httphandlers.go
+++ b/httphandlers.go
@@ -56,26 +56,13 @@ func initHTTPHandlers() {
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-<<<<<<< HEAD
-<<<<<<< HEAD
-	io.WriteString(w, `{"alive": true}`)
-=======
-=======
->>>>>>> e44e154 (docs: update endpoint list with /healthz and /readyz)
 	_, err := w.Write([]byte(`{"alive": true}`))
 	if err != nil {
 		logger.
 			L().
-<<<<<<< HEAD
 			Ctx(r.Context()).
 			Error("failed to write response")
 	}
->>>>>>> a4cf2e0 (a)
-=======
-			Ctx(context.TODO()).
-			Error("failed to write response")
-	}
->>>>>>> e44e154 (docs: update endpoint list with /healthz and /readyz)
 }
 
 // setupReadyz set the atomic value to start checking the probe.

--- a/httphandlers_test.go
+++ b/httphandlers_test.go
@@ -1,0 +1,88 @@
+// httphandlers_test.go
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthzHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test HTTP status OK
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(healthzHandler)
+	handler.ServeHTTP(rr, req)
+	if !assert.Equal(t, http.StatusOK, rr.Code) {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			rr.Code, http.StatusOK)
+	}
+
+	// test HTTP body
+	expected := `{"alive": true}`
+	if !assert.Equal(t, expected, rr.Body.String()) {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}
+
+func TestReadyzHandler(t *testing.T) {
+	req, err := http.NewRequest("GET", "/readyz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ready := &atomic.Value{}
+	ready.Store(true)
+	notReady := &atomic.Value{}
+	notReady.Store(false)
+
+	tests := []struct {
+		name           string
+		isReady        *atomic.Value
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "test_503",
+			isReady:        notReady,
+			expectedStatus: 503,
+			expectedBody:   "Service Unavailable\n",
+		},
+		{
+			name:           "test_200",
+			isReady:        ready,
+			expectedStatus: 200,
+			expectedBody:   `{"ready": true}`,
+		},
+	}
+
+	// test HTTP status OK
+	for _, tt := range tests {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(readyzHandler(tt.isReady))
+		handler.ServeHTTP(rr, req)
+		if !assert.Equal(t, tt.expectedStatus, rr.Code) {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				rr.Code, tt.expectedStatus)
+		}
+	}
+
+	// test HTTP body
+	for _, tt := range tests {
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(readyzHandler(tt.isReady))
+		handler.ServeHTTP(rr, req)
+		if !assert.Equal(t, tt.expectedBody, rr.Body.String()) {
+			t.Errorf("handler returned unexpected body: got %v want %v",
+				rr.Body.String(), tt.expectedBody)
+		}
+	}
+}


### PR DESCRIPTION
## Overview
This PR provides 2 new endpoints:
* `/healthz`
* `/readyz`

to be used with **liveness** and **readiness** probes in kubernetes.

## How to Test
I provided a couple of unit-tests, one for each handler function:
```
go test -v . -run TestHealthzHandler
go test -v . -run TestReadyzHandler
```
 
## Related issues/PRs:
This PR is related to this one in **kubescape**: [1224](https://github.com/kubescape/kubescape/pull/1224).

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
