### PR TITLE
fix: remove deprecated endpoint

### DIFF
--- a/httphandlers.go
+++ b/httphandlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync/atomic"
 
 	"github.com/kubescape/go-logger"
@@ -23,20 +22,6 @@ func initHTTPHandlers() {
 	// enable handlers for liveness and readiness probes.
 	http.HandleFunc("/healthz", healthzHandler)
 	http.HandleFunc("/readyz", readyzHandler(isReady))
-
-	http.HandleFunc("/kubeletcommandline", func(rw http.ResponseWriter, r *http.Request) {
-		proc, err := sensor.LocateKubeletProcess()
-		if err != nil {
-			http.Error(rw, fmt.Sprintf("failed to sense kubelet conf: %v", err), http.StatusInternalServerError)
-			return
-		}
-
-		cmdLine := strings.Join(proc.CmdLine, " ")
-		rw.WriteHeader(http.StatusOK)
-		if _, err := rw.Write([]byte(cmdLine)); err != nil {
-			logger.L().Ctx(r.Context()).Error("In kubeletcommandline handler failed to write", helpers.Error(err))
-		}
-	})
 	// WARNING: the below http requests are used by library: kubescape/core/pkg/hostsensorutils/hostsensorgetfrompod.go
 	http.HandleFunc("/osrelease", osReleaseHandler)
 	http.HandleFunc("/kernelversion", kernelVersionHandler)

--- a/sensor/kubelet.go
+++ b/sensor/kubelet.go
@@ -85,7 +85,7 @@ func SenseKubeletInfo(ctx context.Context) (*KubeletInfo, error) {
 
 	kubeletProcess, err := LocateKubeletProcess()
 	if err != nil {
-		return &ret, fmt.Errorf("failed to LocateKubeletProcess: %w", err)
+		return &ret, fmt.Errorf("failed to Locate kubelet process: %w", err)
 	}
 
 	// Serivce files
@@ -150,20 +150,4 @@ func kubeletExtractCAFileFromConf(content []byte) (string, error) {
 	}
 
 	return kubeletConfig.Authentication.X509.ClientCAFile, nil
-}
-
-// Deprecated: use SenseKubeletInfo for more information.
-// Return the content of kubelet config file
-func SenseKubeletConfigurations() ([]byte, error) {
-	kubeletProcess, err := LocateKubeletProcess()
-	if err != nil {
-		return nil, fmt.Errorf("failed to LocateKubeletProcess: %w", err)
-	}
-	kubeletConfFileLocation, ok := kubeletProcess.GetArg(kubeletConfigArgName)
-	if !ok || kubeletConfFileLocation == "" {
-		return nil, fmt.Errorf("in SenseKubeletConfigurations failed to find kubelet config File location: %v", kubeletProcess)
-	}
-
-	logger.L().Debug("config loaction", helpers.String("kubeletConfFileLocation", kubeletConfFileLocation))
-	return ReadKubeletConfig(kubeletProcess.ContaineredPath(kubeletConfFileLocation))
 }


### PR DESCRIPTION
## Overview
`/kubeletcommandline` has been replaced by `/kubeletinfo` endpoint.


## Related issues/PRs:
Related issue: [SUB-1078](https://cyberarmor-io.atlassian.net/browse/SUB-1078)

## Checklist before requesting a review

- [X] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] New and existing unit tests pass locally with my changes
