### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/e2e/cloudproviderinfo_test.go
+++ b/e2e/cloudproviderinfo_test.go
@@ -2,7 +2,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/kubescape/host-scanner/sensor"
@@ -30,7 +30,7 @@ var _ = Describe("Cloudproviderinfo", func() {
 		It("should return the expected value of CloudProviderInfo", func() {
 			resultBody := &sensor.CloudProviderInfo{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/cniinfo_test.go
+++ b/e2e/cniinfo_test.go
@@ -2,7 +2,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/kubescape/host-scanner/sensor"
@@ -29,7 +29,7 @@ var _ = Describe("CniInfo", func() {
 		It("should return the expected value of CNIInfo", func() {
 			resultBody := &sensor.CNIInfo{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/controlplaneinfo_test.go
+++ b/e2e/controlplaneinfo_test.go
@@ -4,7 +4,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
@@ -32,7 +32,7 @@ var _ = Describe("ControlPlaneInfo", func() {
 		It("should return the expected value of PKIDir and PKIFiles", func() {
 			resultBody := &sensor.ControlPlaneInfo{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/kubeletinfo_test.go
+++ b/e2e/kubeletinfo_test.go
@@ -2,7 +2,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/kubescape/host-scanner/sensor"
@@ -29,7 +29,7 @@ var _ = Describe("Kubeletinfo", func() {
 		It("should return the expected value of KubeletInfo", func() {
 			resultBody := &sensor.KubeletInfo{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/kubeproxyinfo_test.go
+++ b/e2e/kubeproxyinfo_test.go
@@ -2,7 +2,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	sensor "github.com/kubescape/host-scanner/sensor"
@@ -29,7 +29,7 @@ var _ = Describe("KubeProxyInfo", func() {
 		It("should return the expected value of KubeProxyInfo", func() {
 			resultBody := &sensor.KubeProxyInfo{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/linuxsecurityhardening_test.go
+++ b/e2e/linuxsecurityhardening_test.go
@@ -4,7 +4,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	ds "github.com/kubescape/host-scanner/sensor/datastructures"
@@ -31,7 +31,7 @@ var _ = Describe("LinuxSecurityHardening", func() {
 		It("should return the expected value of LinuxSecurityHardeningStatus", func() {
 			resultBody := &ds.LinuxSecurityHardeningStatus{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, resultBody)

--- a/e2e/openedports_test.go
+++ b/e2e/openedports_test.go
@@ -4,7 +4,7 @@ package e2e_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/kubescape/host-scanner/sensor"
@@ -41,7 +41,7 @@ var _ = Describe("Openedports", func() {
 			}
 			jsonOpenedPortsInfo := &sensor.OpenPortsStatus{}
 
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = json.Unmarshal(resBody, jsonOpenedPortsInfo)

--- a/e2e/osrelease_test.go
+++ b/e2e/osrelease_test.go
@@ -3,7 +3,7 @@
 package e2e_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
@@ -29,7 +29,7 @@ var _ = Describe("OsRelease", func() {
 			Expect(res.StatusCode).To(BeEquivalentTo(200))
 		})
 		It("should return the expected value", func() {
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Ω(string(resBody)).Should(ContainSubstring(expectedResult))
 		})
 	})

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -1,7 +1,7 @@
 package e2e_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
@@ -27,7 +27,7 @@ var _ = Describe("Version", func() {
 			Expect(res.StatusCode).To(BeEquivalentTo(200))
 		})
 		It("should return the expected value", func() {
-			resBody, err = ioutil.ReadAll(res.Body)
+			resBody, err = io.ReadAll(res.Body)
 			Expect(string(resBody)).To(BeEquivalentTo(expectedResult))
 		})
 	})


### PR DESCRIPTION
## Overview
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

## Additional Information


## How to Test


## Examples/Screenshots


## Related issues/PRs:

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

