### PR TITLE
CI: Add SBOM Generation and Update E2E Tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,19 @@ jobs:
         run: docker login -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
 
       - name: Build the Docker image
-        run: docker buildx build . --file build/Dockerfile --tag ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.image-version.outputs.IMAGE_VERSION }} --tag ${{ steps.image-name.outputs.IMAGE_NAME }}:latest --build-arg BUILD_VERSION=${{ steps.image-version.outputs.IMAGE_VERSION }} --push --platform linux/amd64,linux/arm64
+        run: docker \
+          buildx \
+          build . \
+          --file build/Dockerfile \
+          --tag ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.image-version.outputs.IMAGE_VERSION }} \
+          --tag ${{ steps.image-name.outputs.IMAGE_NAME }}:latest \
+          --build-arg BUILD_VERSION=${{ steps.image-version.outputs.IMAGE_VERSION }} \
+          --push \
+          --platform linux/amd64,linux/arm64
         env: 
           CGO_ENABLED: 0
+      
+      - name: Generate SBOM for container image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.image-version.outputs.IMAGE_VERSION }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -161,9 +161,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          ref: 'fix/add-conditional-output-to-aks'
           repository: armosec/terraform-test-clusters
+          ref: 'fix/add-conditional-output-to-aks'
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
           #token: ${{ secrets.GH_TOKEN_TERRAFORM_TEST_CLUSTER }}
 
       - uses: azure/login@v1

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -158,6 +158,8 @@ jobs:
     steps:
       - name: Download terraform scripts
         uses: actions/checkout@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           ref: 'fix/add-conditional-output-to-aks'
           repository: armosec/terraform-test-clusters

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -163,7 +163,8 @@ jobs:
         with:
           ref: 'fix/add-conditional-output-to-aks'
           repository: armosec/terraform-test-clusters
-          token: ${{ secrets.GH_TOKEN_TERRAFORM_TEST_CLUSTER }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          #token: ${{ secrets.GH_TOKEN_TERRAFORM_TEST_CLUSTER }}
 
       - uses: azure/login@v1
         with:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ On a new terminal, view pod logs:
 kubectl logs <host-scanner-pod-name> --namespace <namespace> -f
 ```
 
+## SBOM verification
+
+We currently generate and upload **SBOM** of our **docker** image.
+
+To scan for vulnerabilities, our recommendation is to use [grype](https://github.com/anchore/grype).
+
 ## Contributions
 
 Thanks to all our contributors! Check out our [CONTRIBUTING](https://github.com/kubescape/kubescape/blob/master/CONTRIBUTING.md) file to learn how to join them.


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the generation of Software Bill of Materials (SBOM) for the Docker image as part of the CI process. It also updates the end-to-end tests workflow and adds a section in the README about SBOM verification.

___
## PR Main Files Walkthrough:
-`.github/workflows/build.yaml`: Added a new step in the CI process to generate SBOM for the Docker image using the anchore/sbom-action.
-`.github/workflows/e2e-tests.yaml`: Updated the workflow to use a different GitHub token and added an environment variable for the GitHub token.
-`README.md`: Added a new section about SBOM verification, recommending the use of grype for vulnerability scanning.
