### PR TITLE
fix: filter out endpoints from otel

### DIFF
--- a/httphandlers.go
+++ b/httphandlers.go
@@ -12,7 +12,11 @@ import (
 	"github.com/kubescape/host-scanner/sensor"
 )
 
-var BuildVersion string
+var (
+	BuildVersion string
+	healthzEP    = "/healthz"
+	readyzEP     = "/readyz"
+)
 
 func initHTTPHandlers() {
 	// setup readiness probe.
@@ -20,8 +24,8 @@ func initHTTPHandlers() {
 	setupReadyz(isReady)
 
 	// enable handlers for liveness and readiness probes.
-	http.HandleFunc("/healthz", healthzHandler)
-	http.HandleFunc("/readyz", readyzHandler(isReady))
+	http.HandleFunc(healthzEP, healthzHandler)
+	http.HandleFunc(readyzEP, readyzHandler(isReady))
 	// WARNING: the below http requests are used by library: kubescape/core/pkg/hostsensorutils/hostsensorgetfrompod.go
 	http.HandleFunc("/osrelease", osReleaseHandler)
 	http.HandleFunc("/kernelversion", kernelVersionHandler)


### PR DESCRIPTION
## Overview
This PR excludes `/readyz` and `/healthz` from telemetry

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

